### PR TITLE
feat(registry): serve raw .ts alongside each block JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,31 @@ shadcn model applied to CLI infrastructure. No runtime dependency, no framework 
 
 ## Install one block
 
+Every block is served as a raw `.ts` file. One curl, no tooling:
+
+```bash
+curl -o src/agent/trust-ladder.ts https://cligentic.railly.dev/r/trust-ladder.ts
+```
+
+Or let the shadcn CLI place the files and resolve dependencies for you:
+
 ```bash
 bunx shadcn@latest add https://cligentic.railly.dev/r/trust-ladder.json
 ```
 
-This drops into your project:
+Either way you end up with:
 
 ```
 src/agent/
   trust-ladder.ts     # TrustLevel enum (T0-T3) + approveGate() + renderPreview()
   json-mode.ts        # --json flag detection + structured emit helpers
   error-map.ts        # AppError with human message + actionable hint
+```
+
+`trust-ladder` needs `json-mode` and `error-map`, because the gate uses JSON-mode detection to know when to throw instead of prompt, and the error type to throw something structured. The CLI pulls those in automatically. With curl, fetch them too, or read the dependency list:
+
+```bash
+curl -s https://cligentic.railly.dev/r/trust-ladder.json | jq -r '.registryDependencies[]?'
 ```
 
 `approveGate()` is the core: T0/T1 pass through silently, T2 prompts for confirmation, T3 requires `--yes --confirm <id>`. In `--json` mode or piped input, any T2+ gate throws instead of prompting, so agents get a structured error, not a hanging prompt.

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -51,6 +51,19 @@ const nextConfig: NextConfig = {
           { key: "cache-control", value: "public, max-age=300, s-maxage=300" },
         ],
       },
+      {
+        // Raw block sources. Static servers map the .ts extension to
+        // video/mp2t (MPEG transport stream), which makes browsers try to
+        // download a block instead of displaying it. Override it so the
+        // files read as source in a browser and in curl alike.
+        source: "/r/:block*.ts",
+        headers: [
+          {
+            key: "content-type",
+            value: "text/plain; charset=utf-8",
+          },
+        ],
+      },
     ];
   },
 };

--- a/site/public/r/api-key-wizard.ts
+++ b/site/public/r/api-key-wizard.ts
@@ -1,0 +1,155 @@
+// cligentic block: api-key-wizard
+//
+// Interactive first-run wizard for API-key-authenticated CLIs. Prompts
+// for the key, validates it against the live API, and persists the
+// result. The three side effects are split into callbacks so you can
+// drop this into any CLI without coupling to a specific config format
+// (TOML, JSON, env file, keychain).
+//
+// Design rules:
+//   1. Prompt first, validate second, save last. Never save an unvalidated key.
+//   2. Mask input (clack password). Never print the raw key.
+//   3. All long-running steps (validate, save) expose a spinner.
+//   4. Validator returns a typed "identity" object — whatever `whoami`-ish
+//      data your API returns. The wizard surfaces it on success ("Authenticated
+//      as <email>") so the user knows they pasted the right key.
+//   5. On cancel the caller decides the exit code. The wizard throws
+//      ApiKeyWizardCancelled; never calls process.exit.
+//   6. On validation failure the wizard throws ApiKeyWizardValidationFailed
+//      with the underlying error. Nothing is saved.
+//
+// Usage:
+//   import { runApiKeyWizard } from "./agent/api-key-wizard";
+//
+//   await runApiKeyWizard({
+//     appName: "v0",
+//     keyLocationHint: "https://v0.app/chat/settings/keys",
+//     validateKey: async (key) => {
+//       const res = await fetch("https://api.v0.dev/v1/user", {
+//         headers: { Authorization: `Bearer ${key}` },
+//       });
+//       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+//       return await res.json();
+//     },
+//     identityLabel: (user) => user.email ?? user.id ?? "unknown",
+//     saveKey: async (key) => {
+//       await saveProfile("default", { auth: { api_key: key } });
+//     },
+//     shapeHint: (v) => (v.startsWith("v1:") || v.length > 20 ? undefined : "That does not look right"),
+//   });
+//
+// Depends on:
+//   - @clack/prompts (password, spinner, log, cancel, isCancel)
+
+import * as p from '@clack/prompts'
+
+export type ApiKeyWizardOptions<Identity> = {
+  /** Display name of your CLI, used in prompts. e.g. "v0", "hapi", "sunat". */
+  appName: string
+  /** URL or instruction where the user can get a key. Shown in the prompt. */
+  keyLocationHint: string
+  /**
+   * Called with the raw key to confirm it's valid against your API. Return
+   * whatever identity object your `/user` or `/me` endpoint returns. Throw
+   * on failure; the thrown error message is surfaced to the user.
+   */
+  validateKey: (key: string) => Promise<Identity>
+  /** Pick a user-facing label from the identity object (email, name, id). */
+  identityLabel: (identity: Identity) => string
+  /**
+   * Called once the key is validated. Typical implementations: write to a
+   * TOML/JSON profile, export to an env file, push to the OS keychain.
+   * Runs inside the save spinner.
+   */
+  saveKey: (key: string, identity: Identity) => Promise<void>
+  /**
+   * Optional synchronous sanity check before the API probe. Return
+   * `undefined` if the key shape is plausible, or an error string to
+   * re-prompt. If omitted, any non-empty string is allowed.
+   */
+  shapeHint?: (key: string) => string | undefined
+  /** Optional minimum key length. Defaults to 10. */
+  minLength?: number
+  /** Optional intro title shown above the prompt. Defaults to `${appName} init`. */
+  title?: string
+  /** Label to show during validation. Defaults to "Validating key…". */
+  validateLabel?: string
+  /** Label to show during save. Defaults to "Saving credentials…". */
+  saveLabel?: string
+}
+
+export class ApiKeyWizardCancelled extends Error {
+  constructor() {
+    super('User cancelled the api-key wizard')
+    this.name = 'ApiKeyWizardCancelled'
+  }
+}
+
+export class ApiKeyWizardValidationFailed extends Error {
+  // `cause` is a standard Error field; declare the override explicitly
+  // so strict TS configs (noImplicitOverride) don't complain.
+  override readonly cause: unknown
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'ApiKeyWizardValidationFailed'
+    this.cause = cause
+  }
+}
+
+export type ApiKeyWizardResult<Identity> = {
+  /** The raw key the user entered (already validated + saved). */
+  key: string
+  /** The identity object returned by `validateKey`. */
+  identity: Identity
+  /** The user-facing label derived via `identityLabel`. */
+  label: string
+}
+
+/**
+ * Runs the interactive wizard end-to-end. Returns the saved key + identity
+ * on success. Throws ApiKeyWizardCancelled or ApiKeyWizardValidationFailed
+ * otherwise — never calls process.exit.
+ */
+export async function runApiKeyWizard<Identity>(
+  opts: ApiKeyWizardOptions<Identity>,
+): Promise<ApiKeyWizardResult<Identity>> {
+  const minLength = opts.minLength ?? 10
+  const title = opts.title ?? `${opts.appName} init`
+
+  p.intro(title)
+
+  const keyInput = await p.password({
+    message: `Paste your ${opts.appName} API key (grab one at ${opts.keyLocationHint}):`,
+    mask: '•',
+    validate: (v) => {
+      if (!v || v.length < minLength) return 'Key looks too short.'
+      if (opts.shapeHint) return opts.shapeHint(v)
+      return undefined
+    },
+  })
+  if (p.isCancel(keyInput)) {
+    p.cancel('Cancelled. Nothing saved.')
+    throw new ApiKeyWizardCancelled()
+  }
+  const key = keyInput as string
+
+  const validateSpin = p.spinner()
+  validateSpin.start(opts.validateLabel ?? 'Validating key…')
+  let identity: Identity
+  try {
+    identity = await opts.validateKey(key)
+  } catch (err) {
+    validateSpin.stop(`Validation failed: ${err instanceof Error ? err.message : String(err)}`)
+    p.cancel('Nothing saved. Double-check the key and try again.')
+    throw new ApiKeyWizardValidationFailed(err)
+  }
+  const label = opts.identityLabel(identity)
+  validateSpin.stop(`Key valid. Authenticated as ${label}.`)
+
+  const saveSpin = p.spinner()
+  saveSpin.start(opts.saveLabel ?? 'Saving credentials…')
+  await opts.saveKey(key, identity)
+  saveSpin.stop('Credentials saved.')
+
+  return { key, identity, label }
+}

--- a/site/public/r/argv.ts
+++ b/site/public/r/argv.ts
@@ -1,0 +1,83 @@
+// cligentic block: argv
+//
+// Minimal POSIX argv parser for zero-framework CLIs.
+// No dependencies. Handles --flag, --flag value, --flag=value, -f, positional args.
+//
+// Usage:
+//   import { parseArgv } from "./foundation/argv";
+//
+//   const args = parseArgv();
+//   // myapp --dry-run --output=file.json input.txt
+//   // => { _: ["input.txt"], dryRun: true, output: "file.json" }
+
+export type ParsedArgs = { _: string[]; [key: string]: unknown };
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Parses process.argv.slice(2) by default, or the provided argv array.
+ *
+ * Rules:
+ *   --flag          → flag: true
+ *   --flag value    → flag: "value" (when next token doesn't start with -)
+ *   --flag=value    → flag: "value"
+ *   -f              → f: true
+ *   -fv             → f: true, v: true (combined short flags)
+ *   --              → stop flag parsing; rest goes into _
+ *   kebab-case keys → camelCase (--dry-run → dryRun)
+ */
+export function parseArgv(argv: string[] = process.argv.slice(2)): ParsedArgs {
+  const result: ParsedArgs = { _: [] };
+  let i = 0;
+  let stopped = false;
+
+  while (i < argv.length) {
+    const arg = argv[i];
+
+    if (stopped || arg === undefined) {
+      if (arg !== undefined) result._.push(arg);
+      i++;
+      continue;
+    }
+
+    if (arg === "--") {
+      stopped = true;
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      const eqIdx = arg.indexOf("=");
+      if (eqIdx !== -1) {
+        const key = kebabToCamel(arg.slice(2, eqIdx));
+        result[key] = arg.slice(eqIdx + 1);
+      } else {
+        const key = kebabToCamel(arg.slice(2));
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("-")) {
+          result[key] = next;
+          i++;
+        } else {
+          result[key] = true;
+        }
+      }
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg.length > 1) {
+      for (let j = 1; j < arg.length; j++) {
+        result[arg[j] as string] = true;
+      }
+      i++;
+      continue;
+    }
+
+    result._.push(arg);
+    i++;
+  }
+
+  return result;
+}

--- a/site/public/r/atomic-write.ts
+++ b/site/public/r/atomic-write.ts
@@ -1,0 +1,88 @@
+// cligentic block: atomic-write
+//
+// Write files atomically: write to a temp file, fsync, rename. Prevents
+// corruption from crashes, power loss, or concurrent CLI processes.
+//
+// Design rules:
+//   1. Write to a .tmp sibling file first.
+//   2. fsync before rename to ensure data hits disk.
+//   3. rename() is atomic on POSIX. On Windows, unlink target first.
+//   4. Enforce file mode (default 0o644, 0o600 for secrets).
+//   5. Create parent directories if they don't exist.
+//
+// Usage:
+//   import { atomicWrite, atomicWriteJson } from "./foundation/atomic-write";
+//
+//   atomicWrite("~/.myapp/config.toml", tomlString);
+//   atomicWriteJson("~/.myapp/session.json", session, { mode: 0o600 });
+
+import {
+  closeSync,
+  existsSync,
+  fdatasyncSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { platform } from "node:os";
+
+export type WriteOptions = {
+  /** File permissions. Default 0o644. Use 0o600 for secrets. */
+  mode?: number;
+  /** Encoding for string content. Default "utf8". */
+  encoding?: BufferEncoding;
+};
+
+/**
+ * Writes content to a file atomically. The file either contains the old
+ * content or the new content, never a partial write.
+ *
+ * Steps:
+ *   1. Create parent directories if missing
+ *   2. Write to {path}.tmp
+ *   3. fsync to flush to disk
+ *   4. On Windows: unlink target if it exists (rename doesn't overwrite)
+ *   5. rename .tmp to target (atomic on POSIX)
+ */
+export function atomicWrite(
+  filePath: string,
+  content: string | Buffer,
+  options: WriteOptions = {},
+): void {
+  const { mode = 0o644, encoding = "utf8" } = options;
+  const dir = dirname(filePath);
+  const tmpPath = join(dir, `.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`);
+
+  mkdirSync(dir, { recursive: true });
+
+  const data = typeof content === "string" ? Buffer.from(content, encoding) : content;
+  const fd = openSync(tmpPath, "w", mode);
+  try {
+    writeSync(fd, data);
+    fdatasyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  // Windows rename() fails if target exists. Unlink first.
+  if (platform() === "win32" && existsSync(filePath)) {
+    unlinkSync(filePath);
+  }
+
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Convenience: atomically write a JSON-serializable value with 2-space
+ * indentation and a trailing newline. Common pattern for config/session files.
+ */
+export function atomicWriteJson(
+  filePath: string,
+  value: unknown,
+  options: WriteOptions = {},
+): void {
+  atomicWrite(filePath, `${JSON.stringify(value, null, 2)}\n`, options);
+}

--- a/site/public/r/audit-lifecycle.json
+++ b/site/public/r/audit-lifecycle.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "audit-lifecycle",
+  "title": "audit-lifecycle",
+  "description": "Two-phase append-only audit lifecycle for dangerous or retryable operations: `beginAudit()` writes pending, then `complete()` or `fail()` appends the final record with the same audit id.",
+  "files": [
+    {
+      "path": "registry/foundation/audit-lifecycle.ts",
+      "content": "// cligentic block: audit-lifecycle\n//\n// Two-phase append-only audit records for operations that must survive retries.\n\nimport { appendFileSync, mkdirSync } from \"node:fs\";\nimport { randomUUID } from \"node:crypto\";\nimport { join } from \"node:path\";\n\nexport type AuditLifecycleResult = \"pending\" | \"ok\" | \"error\" | \"blocked\" | \"dry-run\";\n\nexport type AuditLifecycleRecord = {\n  kind: string;\n  command: string;\n  meta?: Record<string, unknown>;\n  tier?: string;\n  profile?: string;\n};\n\nexport type AuditLifecycle = {\n  auditId: string;\n  complete(meta?: Record<string, unknown>): void;\n  fail(meta?: Record<string, unknown>): void;\n  block(meta?: Record<string, unknown>): void;\n  dryRun(meta?: Record<string, unknown>): void;\n};\n\ntype StoredLifecycleRecord = AuditLifecycleRecord & {\n  ts: string;\n  result: AuditLifecycleResult;\n  meta: Record<string, unknown>;\n};\n\nfunction todayFilename(): string {\n  return `${new Date().toISOString().slice(0, 10)}.jsonl`;\n}\n\nexport function beginAudit(\n  auditDir: string,\n  record: AuditLifecycleRecord,\n  opts: { auditId?: string } = {},\n): AuditLifecycle {\n  const auditId = opts.auditId ?? randomUUID();\n  const started = Date.now();\n  const baseMeta = { ...(record.meta ?? {}), audit_id: auditId };\n\n  appendLifecycleRecord(auditDir, record, \"pending\", baseMeta);\n\n  const finish = (result: Exclude<AuditLifecycleResult, \"pending\">, meta = {}) => {\n    appendLifecycleRecord(auditDir, record, result, {\n      ...baseMeta,\n      ...meta,\n      duration_ms: Date.now() - started,\n    });\n  };\n\n  return {\n    auditId,\n    complete: (meta) => finish(\"ok\", meta),\n    fail: (meta) => finish(\"error\", meta),\n    block: (meta) => finish(\"blocked\", meta),\n    dryRun: (meta) => finish(\"dry-run\", meta),\n  };\n}\n\nexport function appendLifecycleRecord(\n  auditDir: string,\n  record: AuditLifecycleRecord,\n  result: AuditLifecycleResult,\n  meta: Record<string, unknown> = {},\n): void {\n  mkdirSync(auditDir, { recursive: true });\n  const file = join(auditDir, todayFilename());\n  const stored: StoredLifecycleRecord = {\n    ts: new Date().toISOString(),\n    ...record,\n    result,\n    meta,\n  };\n  appendFileSync(file, `${JSON.stringify(stored)}\\n`, { mode: 0o600 });\n}\n",
+      "type": "registry:file",
+      "target": "src/cli/foundation/audit-lifecycle.ts"
+    }
+  ],
+  "type": "registry:file"
+}

--- a/site/public/r/audit-lifecycle.ts
+++ b/site/public/r/audit-lifecycle.ts
@@ -1,0 +1,80 @@
+// cligentic block: audit-lifecycle
+//
+// Two-phase append-only audit records for operations that must survive retries.
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+export type AuditLifecycleResult = "pending" | "ok" | "error" | "blocked" | "dry-run";
+
+export type AuditLifecycleRecord = {
+  kind: string;
+  command: string;
+  meta?: Record<string, unknown>;
+  tier?: string;
+  profile?: string;
+};
+
+export type AuditLifecycle = {
+  auditId: string;
+  complete(meta?: Record<string, unknown>): void;
+  fail(meta?: Record<string, unknown>): void;
+  block(meta?: Record<string, unknown>): void;
+  dryRun(meta?: Record<string, unknown>): void;
+};
+
+type StoredLifecycleRecord = AuditLifecycleRecord & {
+  ts: string;
+  result: AuditLifecycleResult;
+  meta: Record<string, unknown>;
+};
+
+function todayFilename(): string {
+  return `${new Date().toISOString().slice(0, 10)}.jsonl`;
+}
+
+export function beginAudit(
+  auditDir: string,
+  record: AuditLifecycleRecord,
+  opts: { auditId?: string } = {},
+): AuditLifecycle {
+  const auditId = opts.auditId ?? randomUUID();
+  const started = Date.now();
+  const baseMeta = { ...(record.meta ?? {}), audit_id: auditId };
+
+  appendLifecycleRecord(auditDir, record, "pending", baseMeta);
+
+  const finish = (result: Exclude<AuditLifecycleResult, "pending">, meta = {}) => {
+    appendLifecycleRecord(auditDir, record, result, {
+      ...baseMeta,
+      ...meta,
+      duration_ms: Date.now() - started,
+    });
+  };
+
+  return {
+    auditId,
+    complete: (meta) => finish("ok", meta),
+    fail: (meta) => finish("error", meta),
+    block: (meta) => finish("blocked", meta),
+    dryRun: (meta) => finish("dry-run", meta),
+  };
+}
+
+export function appendLifecycleRecord(
+  auditDir: string,
+  record: AuditLifecycleRecord,
+  result: AuditLifecycleResult,
+  meta: Record<string, unknown> = {},
+): void {
+  mkdirSync(auditDir, { recursive: true });
+  const file = join(auditDir, todayFilename());
+  const stored: StoredLifecycleRecord = {
+    ts: new Date().toISOString(),
+    ...record,
+    result,
+    meta,
+  };
+  appendFileSync(file, `${JSON.stringify(stored)}\n`, { mode: 0o600 });
+}

--- a/site/public/r/audit-log.ts
+++ b/site/public/r/audit-log.ts
@@ -1,0 +1,100 @@
+// cligentic block: audit-log
+//
+// Append-only JSONL audit trail. One file per day, rotated automatically.
+// Every meaningful action your CLI takes gets a record.
+//
+// Design rules:
+//   1. Append-only. Never overwrite, never delete, never truncate.
+//   2. One JSON object per line (JSONL). Machine-readable, grep-friendly.
+//   3. Per-day rotation: audit/2026-04-09.jsonl, audit/2026-04-10.jsonl.
+//   4. File mode 0o600 (audit logs may contain sensitive operation details).
+//   5. Timestamp is ISO 8601 UTC, always first field.
+//
+// Usage:
+//   import { audit, tailAudit } from "./foundation/audit-log";
+//
+//   await audit(auditDir, {
+//     kind: "order.placed",
+//     command: "order buy AAPL",
+//     result: "ok",
+//     meta: { orderId: "abc-123" },
+//   });
+//
+//   const recent = tailAudit(auditDir, 10);
+
+import { appendFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type AuditRecord = {
+  /** What happened. Use dot-notation: "order.placed", "auth.login", "config.updated". */
+  kind: string;
+  /** The full command string. */
+  command: string;
+  /** Outcome of the operation. */
+  result: "ok" | "error" | "blocked" | "dry-run";
+  /** Optional structured metadata. */
+  meta?: Record<string, unknown>;
+  /** Optional tier level (for safety-stack CLIs). */
+  tier?: string;
+  /** Optional profile name. */
+  profile?: string;
+};
+
+type StoredRecord = AuditRecord & {
+  ts: string;
+};
+
+function todayFilename(): string {
+  return `${new Date().toISOString().slice(0, 10)}.jsonl`;
+}
+
+/**
+ * Appends an audit record to today's log file. Creates the audit
+ * directory and file if they don't exist. Append is atomic at the
+ * OS level for lines under 4KB (PIPE_BUF on POSIX).
+ */
+export function audit(auditDir: string, record: AuditRecord): void {
+  mkdirSync(auditDir, { recursive: true });
+  const file = join(auditDir, todayFilename());
+  const stored: StoredRecord = { ts: new Date().toISOString(), ...record };
+  appendFileSync(file, `${JSON.stringify(stored)}\n`, { mode: 0o600 });
+}
+
+/**
+ * Reads the last N records from the audit log. Reads today's file first,
+ * then yesterday's, etc., until N records are collected or no more files.
+ * Returns newest-first.
+ */
+export function tailAudit(auditDir: string, n = 20): StoredRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(auditDir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+
+  const results: StoredRecord[] = [];
+  for (const file of files) {
+    if (results.length >= n) break;
+    try {
+      const content = readFileSync(join(auditDir, file), "utf8");
+      const lines = content.trim().split("\n").filter(Boolean).reverse();
+      for (const line of lines) {
+        if (results.length >= n) break;
+        try {
+          results.push(JSON.parse(line) as StoredRecord);
+        } catch {
+          // skip malformed lines
+        }
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  return results;
+}
+

--- a/site/public/r/banner.ts
+++ b/site/public/r/banner.ts
@@ -1,0 +1,127 @@
+// cligentic block: banner
+//
+// Gradient ASCII wordmark for your CLI. Shown on bare invoke or --help.
+// Respects NO_COLOR and non-TTY environments.
+//
+// Usage:
+//   import { printBanner } from "./foundation/banner";
+//
+//   printBanner({
+//     name: "myapp",
+//     tagline: "The CLI for shipping fast.",
+//     version: "1.2.0",
+//     gradient: ["#FF6B1A", "#DB2627"],
+//   });
+
+import { shouldColor } from "../platform/detect";
+
+export type BannerOptions = {
+  name: string;
+  tagline?: string;
+  version?: string;
+  /** Two hex colors for the vertical gradient [top, bottom]. */
+  gradient?: [string, string];
+};
+
+/**
+ * Prints a branded banner to stderr. Falls back to plain text
+ * when NO_COLOR is set or stdout is not a TTY.
+ */
+export function printBanner(opts: BannerOptions): void {
+  const { name, tagline, version, gradient = ["#FFFFFF", "#8A8A8A"] } = opts;
+  const color = shouldColor();
+
+  if (!color) {
+    const v = version ? ` v${version}` : "";
+    process.stderr.write(`\n  ${name}${v}\n`);
+    if (tagline) process.stderr.write(`  ${tagline}\n`);
+    process.stderr.write("\n");
+    return;
+  }
+
+  const lines = toAsciiBlock(name.toUpperCase());
+  const [from, to] = gradient.map(hexToRgb);
+
+  process.stderr.write("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines.length > 1 ? i / (lines.length - 1) : 0;
+    const r = Math.round(from.r + (to.r - from.r) * t);
+    const g = Math.round(from.g + (to.g - from.g) * t);
+    const b = Math.round(from.b + (to.b - from.b) * t);
+    process.stderr.write(`  \x1b[38;2;${r};${g};${b}m${lines[i]}\x1b[0m\n`);
+  }
+
+  const meta: string[] = [];
+  if (version) meta.push(`v${version}`);
+  if (tagline) meta.push(tagline);
+  if (meta.length) {
+    process.stderr.write(`  \x1b[2m${meta.join("  ·  ")}\x1b[0m\n`);
+  }
+  process.stderr.write("\n");
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace("#", "");
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+/**
+ * Minimal block-letter renderer. Each character is 5 lines tall.
+ * Only uppercase A-Z, 0-9, space, and a few symbols. Unknown chars
+ * become spaces. The user can replace this with a figlet font if
+ * they want fancier output.
+ */
+function toAsciiBlock(text: string): string[] {
+  const out = ["", "", "", "", ""];
+  for (const ch of text) {
+    const glyph = GLYPHS[ch] ?? GLYPHS[" "];
+    for (let row = 0; row < 5; row++) {
+      out[row] += glyph[row] + " ";
+    }
+  }
+  return out;
+}
+
+const GLYPHS: Record<string, string[]> = {
+  A: ["  █  ", " █ █ ", "█████", "█   █", "█   █"],
+  B: ["████ ", "█   █", "████ ", "█   █", "████ "],
+  C: [" ████", "█    ", "█    ", "█    ", " ████"],
+  D: ["████ ", "█   █", "█   █", "█   █", "████ "],
+  E: ["█████", "█    ", "████ ", "█    ", "█████"],
+  F: ["█████", "█    ", "████ ", "█    ", "█    "],
+  G: [" ████", "█    ", "█  ██", "█   █", " ████"],
+  H: ["█   █", "█   █", "█████", "█   █", "█   █"],
+  I: ["█████", "  █  ", "  █  ", "  █  ", "█████"],
+  J: ["█████", "    █", "    █", "█   █", " ███ "],
+  K: ["█   █", "█  █ ", "███  ", "█  █ ", "█   █"],
+  L: ["█    ", "█    ", "█    ", "█    ", "█████"],
+  M: ["█   █", "██ ██", "█ █ █", "█   █", "█   █"],
+  N: ["█   █", "██  █", "█ █ █", "█  ██", "█   █"],
+  O: [" ███ ", "█   █", "█   █", "█   █", " ███ "],
+  P: ["████ ", "█   █", "████ ", "█    ", "█    "],
+  Q: [" ███ ", "█   █", "█ █ █", "█  █ ", " ██ █"],
+  R: ["████ ", "█   █", "████ ", "█  █ ", "█   █"],
+  S: [" ████", "█    ", " ███ ", "    █", "████ "],
+  T: ["█████", "  █  ", "  █  ", "  █  ", "  █  "],
+  U: ["█   █", "█   █", "█   █", "█   █", " ███ "],
+  V: ["█   █", "█   █", "█   █", " █ █ ", "  █  "],
+  W: ["█   █", "█   █", "█ █ █", "██ ██", "█   █"],
+  X: ["█   █", " █ █ ", "  █  ", " █ █ ", "█   █"],
+  Y: ["█   █", " █ █ ", "  █  ", "  █  ", "  █  "],
+  Z: ["█████", "   █ ", "  █  ", " █   ", "█████"],
+  " ": ["     ", "     ", "     ", "     ", "     "],
+  "0": [" ███ ", "█  ██", "█ █ █", "██  █", " ███ "],
+  "1": [" ██  ", "  █  ", "  █  ", "  █  ", "█████"],
+  "2": [" ███ ", "█   █", "  ██ ", " █   ", "█████"],
+  "3": ["████ ", "    █", " ███ ", "    █", "████ "],
+  "4": ["█   █", "█   █", "█████", "    █", "    █"],
+  "5": ["█████", "█    ", "████ ", "    █", "████ "],
+  "6": [" ███ ", "█    ", "████ ", "█   █", " ███ "],
+  "7": ["█████", "    █", "   █ ", "  █  ", "  █  "],
+  "8": [" ███ ", "█   █", " ███ ", "█   █", " ███ "],
+  "9": [" ███ ", "█   █", " ████", "    █", " ███ "],
+};

--- a/site/public/r/config.ts
+++ b/site/public/r/config.ts
@@ -1,0 +1,91 @@
+// cligentic block: config
+//
+// Profile-aware config loader. Reads JSON config from the app's config
+// directory with support for multiple profiles (dev, staging, production).
+//
+// Precedence: env vars > CLI flags > profile config > default config.
+//
+// Usage:
+//   import { loadConfig, saveConfig } from "./foundation/config";
+//
+//   const config = loadConfig<MyConfig>(paths.config, "production");
+//   // reads ~/.config/myapp/config.json, merges profile "production"
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWriteJson } from "./atomic-write";
+
+export type ConfigFile<T> = {
+  defaults?: Partial<T>;
+  profiles?: Record<string, Partial<T>>;
+};
+
+/**
+ * Loads config from a JSON file at {configDir}/config.json.
+ * Merges: defaults <- profile overrides <- env overrides.
+ *
+ * Returns the defaults if no config file exists (never throws for missing file).
+ */
+export function loadConfig<T extends Record<string, unknown>>(
+  configDir: string,
+  profile?: string,
+): T {
+  const filePath = join(configDir, "config.json");
+
+  let file: ConfigFile<T> = {};
+  if (existsSync(filePath)) {
+    try {
+      file = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      // corrupted config, start fresh
+    }
+  }
+
+  const defaults = (file.defaults ?? {}) as T;
+  const profileOverrides = profile && file.profiles?.[profile]
+    ? file.profiles[profile]
+    : {};
+
+  return { ...defaults, ...profileOverrides } as T;
+}
+
+/**
+ * Saves config to {configDir}/config.json using atomic write.
+ * Merges the update into the existing file (preserves other profiles).
+ */
+export function saveConfig<T extends Record<string, unknown>>(
+  configDir: string,
+  update: ConfigFile<T>,
+): void {
+  const filePath = join(configDir, "config.json");
+
+  let existing: ConfigFile<T> = {};
+  if (existsSync(filePath)) {
+    try {
+      existing = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      // corrupted, overwrite
+    }
+  }
+
+  const merged: ConfigFile<T> = {
+    defaults: { ...existing.defaults, ...update.defaults } as Partial<T>,
+    profiles: { ...existing.profiles, ...update.profiles },
+  };
+
+  atomicWriteJson(filePath, merged);
+}
+
+/**
+ * Lists available profile names from the config file.
+ */
+export function listProfiles(configDir: string): string[] {
+  const filePath = join(configDir, "config.json");
+  if (!existsSync(filePath)) return [];
+  try {
+    const file = JSON.parse(readFileSync(filePath, "utf8"));
+    return Object.keys(file.profiles ?? {});
+  } catch {
+    return [];
+  }
+}

--- a/site/public/r/copy-clipboard.ts
+++ b/site/public/r/copy-clipboard.ts
@@ -1,0 +1,84 @@
+// cligentic block: copy-clipboard
+//
+// Copies text to the system clipboard across macOS, Linux (X11 + Wayland),
+// Windows, and WSL. Returns a typed verdict instead of throwing.
+//
+// Usage:
+//   import { copyToClipboard } from "./platform/copy-clipboard";
+//
+//   const result = await copyToClipboard("https://cligentic.railly.dev");
+//   if (!result.copied) {
+//     console.log("Copy this manually:", text);
+//   }
+
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+import { hasCommand, isWsl } from "./detect";
+
+export type CopyResult = {
+  copied: boolean;
+  via: "pbcopy" | "xclip" | "xsel" | "wl-copy" | "clip.exe" | "powershell" | "manual";
+  reason?: string;
+};
+
+export type CopyOptions = {
+  dryRun?: boolean;
+};
+
+function tryExec(cmd: string, text: string): boolean {
+  try {
+    execSync(cmd, { input: text, stdio: ["pipe", "ignore", "ignore"], timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function copyToClipboard(
+  text: string,
+  options: CopyOptions = {},
+): Promise<CopyResult> {
+  const { dryRun = false } = options;
+  const os = platform();
+
+  if (os === "darwin") {
+    if (dryRun) return { copied: true, via: "pbcopy", reason: "would run: pbcopy" };
+    if (tryExec("pbcopy", text)) return { copied: true, via: "pbcopy" };
+    return { copied: false, via: "manual", reason: "pbcopy failed" };
+  }
+
+  if (os === "win32") {
+    if (dryRun) return { copied: true, via: "powershell", reason: "would run: Set-Clipboard" };
+    if (tryExec('powershell.exe -NoProfile -Command "Set-Clipboard -Value $input"', text)) {
+      return { copied: true, via: "powershell" };
+    }
+    return { copied: false, via: "manual", reason: "powershell Set-Clipboard failed" };
+  }
+
+  if (os === "linux" && isWsl()) {
+    if (hasCommand("clip.exe")) {
+      if (dryRun) return { copied: true, via: "clip.exe", reason: "would run: clip.exe" };
+      if (tryExec("clip.exe", text)) return { copied: true, via: "clip.exe" };
+    }
+    return { copied: false, via: "manual", reason: "WSL without clip.exe" };
+  }
+
+  // Linux: Wayland first, then X11
+  if (process.env.WAYLAND_DISPLAY && hasCommand("wl-copy")) {
+    if (dryRun) return { copied: true, via: "wl-copy", reason: "would run: wl-copy" };
+    if (tryExec("wl-copy", text)) return { copied: true, via: "wl-copy" };
+  }
+
+  if (process.env.DISPLAY) {
+    if (hasCommand("xclip")) {
+      if (dryRun) return { copied: true, via: "xclip", reason: "would run: xclip" };
+      if (tryExec("xclip -selection clipboard", text)) return { copied: true, via: "xclip" };
+    }
+    if (hasCommand("xsel")) {
+      if (dryRun) return { copied: true, via: "xsel", reason: "would run: xsel" };
+      if (tryExec("xsel --clipboard --input", text)) return { copied: true, via: "xsel" };
+    }
+  }
+
+  return { copied: false, via: "manual", reason: "no clipboard backend found" };
+}

--- a/site/public/r/detect.ts
+++ b/site/public/r/detect.ts
@@ -1,0 +1,99 @@
+// cligentic block: detect
+//
+// Environment detection helpers shared across platform blocks.
+// Detects WSL, CI, headless environments, and binary availability.
+//
+// Usage:
+//   import { isWsl, isCi, hasCommand } from "./platform/detect";
+
+import { existsSync, readFileSync } from "node:fs";
+import { platform } from "node:os";
+
+/**
+ * Detects WSL (Windows Subsystem for Linux). Reads /proc/version once
+ * and caches the result for the lifetime of the process.
+ */
+let wslCache: boolean | null = null;
+export function isWsl(): boolean {
+  if (wslCache !== null) return wslCache;
+  if (platform() !== "linux") {
+    wslCache = false;
+    return false;
+  }
+  try {
+    const version = readFileSync("/proc/version", "utf8").toLowerCase();
+    wslCache = version.includes("microsoft") || version.includes("wsl");
+  } catch {
+    wslCache = false;
+  }
+  return wslCache;
+}
+
+/**
+ * Detects CI environments. Checks standard CI env vars.
+ */
+export function isCi(): boolean {
+  return Boolean(
+    process.env.CI ||
+      process.env.CONTINUOUS_INTEGRATION ||
+      process.env.GITHUB_ACTIONS ||
+      process.env.GITLAB_CI ||
+      process.env.CIRCLECI ||
+      process.env.BUILDKITE,
+  );
+}
+
+/**
+ * Detects headless Linux (no graphical display).
+ * WSL is NOT headless because it can open browsers on the Windows host.
+ */
+export function isHeadlessLinux(): boolean {
+  if (platform() !== "linux") return false;
+  if (isWsl()) return false;
+  return !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
+}
+
+/**
+ * Checks if a command exists in PATH. Handles Windows .exe/.cmd/.bat
+ * extensions automatically.
+ */
+export function hasCommand(cmd: string): boolean {
+  const separator = platform() === "win32" ? ";" : ":";
+  const paths = (process.env.PATH || "").split(separator);
+  const exts = platform() === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
+  for (const p of paths) {
+    for (const ext of exts) {
+      if (existsSync(`${p}/${cmd}${ext}`)) return true;
+    }
+  }
+  return false;
+}
+
+// --- Output mode detection (shared by json-mode + next-steps) ---
+
+export type OutputMode = "human" | "json";
+
+export type EmitOptions = {
+  json?: boolean;
+  quiet?: boolean;
+};
+
+/**
+ * Detects whether the CLI should emit structured JSON or human output.
+ * Precedence: explicit --json flag > NO_JSON env > TTY detection > default human.
+ */
+export function detectMode(opts: EmitOptions = {}): OutputMode {
+  if (opts.json === true) return "json";
+  if (process.env.NO_JSON === "1") return "human";
+  if (!process.stdout.isTTY) return "json";
+  return "human";
+}
+
+/**
+ * Detects whether colors should be used. Respects NO_COLOR and FORCE_COLOR.
+ */
+export function shouldColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR) return true;
+  return Boolean(process.stdout.isTTY);
+}

--- a/site/public/r/doctor.ts
+++ b/site/public/r/doctor.ts
@@ -1,0 +1,65 @@
+// cligentic block: doctor
+//
+// Health-check pattern. Run named checks sequentially, emit structured results.
+// Integrates with json-mode for dual output.
+//
+// Usage:
+//   import { runDoctor, renderDoctor } from "./agent/doctor";
+//
+//   const result = await runDoctor([
+//     async () => {
+//       const ok = await ping();
+//       return { name: "api-reachable", ok, detail: ok ? "200 OK" : "timeout" };
+//     },
+//   ]);
+//   renderDoctor(result, opts);
+
+import { type EmitOptions, detectMode, emit } from "./json-mode";
+
+export type DoctorCheck = { name: string; ok: boolean; detail: string };
+
+export type DoctorResult = { ok: boolean; checks: DoctorCheck[] };
+
+/**
+ * Runs checks sequentially. Each check is isolated — a thrown error is
+ * caught and recorded as a failed check so the rest still run.
+ */
+export async function runDoctor(
+  checks: Array<() => Promise<DoctorCheck>>,
+): Promise<DoctorResult> {
+  const results: DoctorCheck[] = [];
+
+  for (const check of checks) {
+    try {
+      results.push(await check());
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      results.push({ name: "unknown", ok: false, detail });
+    }
+  }
+
+  return { ok: results.every((c) => c.ok), checks: results };
+}
+
+/**
+ * Renders a DoctorResult to stdout.
+ * JSON mode: emits the structured result via emit().
+ * Human mode: prints [OK] / [FAIL] per check, then a summary line.
+ */
+export function renderDoctor(result: DoctorResult, opts: EmitOptions = {}): void {
+  const mode = detectMode(opts);
+
+  if (mode === "json") {
+    emit(result, opts);
+    return;
+  }
+
+  for (const check of result.checks) {
+    const badge = check.ok ? "[OK]  " : "[FAIL]";
+    process.stdout.write(`${badge} ${check.name}: ${check.detail}\n`);
+  }
+
+  const total = result.checks.length;
+  const passed = result.checks.filter((c) => c.ok).length;
+  process.stdout.write(`\n${passed}/${total} checks passed\n`);
+}

--- a/site/public/r/error-map.ts
+++ b/site/public/r/error-map.ts
@@ -1,0 +1,110 @@
+// cligentic block: error-map
+//
+// Typed error class with code, name, human message, and hint. Maps
+// upstream API errors to actionable messages. Agents read the hint
+// field to self-correct.
+//
+// Usage:
+//   import { AppError, mapError } from "./foundation/error-map";
+//
+//   const errors = {
+//     "AUTH_EXPIRED": { name: "AuthExpired", human: "Session expired.", hint: "Run: myapp login" },
+//     "RATE_LIMIT":  { name: "RateLimit", human: "Too many requests.", hint: "Wait 60s and retry." },
+//   };
+//
+//   try { await api.call(); }
+//   catch (err) { throw mapError(err, errors); }
+
+export type ErrorEntry = {
+  name: string;
+  human: string;
+  hint?: string;
+};
+
+export type ErrorMap = Record<string, ErrorEntry>;
+
+export class AppError extends Error {
+  code: string;
+  human: string;
+  hint?: string;
+
+  constructor(code: string, entry: ErrorEntry, cause?: unknown) {
+    super(entry.human);
+    this.name = entry.name;
+    this.code = code;
+    this.human = entry.human;
+    this.hint = entry.hint;
+    if (cause) this.cause = cause;
+  }
+
+  toJSON() {
+    return {
+      ok: false,
+      code: this.code,
+      name: this.name,
+      error: this.human,
+      hint: this.hint,
+    };
+  }
+}
+
+/**
+ * Maps an upstream error to an AppError using the provided error map.
+ * If the error has a `code` property that matches a key in the map,
+ * returns a typed AppError with the mapped message and hint.
+ * Otherwise wraps the original error as-is.
+ */
+export function mapError(err: unknown, errors: ErrorMap): AppError {
+  const code = extractCode(err);
+  if (code && errors[code]) {
+    return new AppError(code, errors[code], err);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new AppError("UNKNOWN", { name: "UnknownError", human: message }, err);
+}
+
+/**
+ * Creates an AppError from an HTTP response. Looks up the status code in
+ * statusMap first, then falls back to extractCode on the body string parsed
+ * as JSON, then returns a generic HTTP error.
+ */
+export function fromHttp(
+  status: number,
+  body: string,
+  statusMap: Record<number, string>,
+  errors: ErrorMap,
+): AppError {
+  const mappedCode = statusMap[status];
+  if (mappedCode && errors[mappedCode]) {
+    return new AppError(mappedCode, errors[mappedCode]);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    parsed = null;
+  }
+  const code = extractCode(parsed);
+  if (code && errors[code]) {
+    return new AppError(code, errors[code]);
+  }
+  return new AppError("HTTP_ERROR", {
+    name: "HttpError",
+    human: `HTTP ${status}`,
+    hint: body.slice(0, 120) || undefined,
+  });
+}
+
+function extractCode(err: unknown): string | null {
+  if (!err || typeof err !== "object") return null;
+  const obj = err as Record<string, unknown>;
+  const candidate =
+    obj.code ??
+    obj.status ??
+    obj.statusCode ??
+    (obj.response && typeof obj.response === "object"
+      ? (obj.response as Record<string, unknown>).status
+      : undefined);
+  if (candidate === undefined || candidate === null) return null;
+  return String(candidate);
+}

--- a/site/public/r/global-flags.ts
+++ b/site/public/r/global-flags.ts
@@ -1,0 +1,65 @@
+// cligentic block: global-flags
+//
+// Standard global flags every agent-first CLI should expose.
+// Returns a typed options object that other blocks (json-mode,
+// killswitch, config) consume.
+//
+// Usage:
+//   import { type GlobalFlags, parseGlobalFlags } from "./foundation/global-flags";
+//
+//   // After your argv parser extracts raw opts:
+//   const flags = parseGlobalFlags(rawOpts);
+//   emit(data, flags);  // json-mode reads flags.json
+//   note("loading...", flags);  // respects flags.quiet
+
+export type GlobalFlags = {
+  /** Emit JSON output for agents. Implied when stdout is piped. */
+  json: boolean;
+  /** Validate without calling upstream. */
+  dryRun: boolean;
+  /** Config profile name. */
+  profile: string | undefined;
+  /** Never prompt, fail fast. For CI and agents. */
+  noInput: boolean;
+  /** Suppress non-essential output. */
+  quiet: boolean;
+  /** Verbose logging to stderr. */
+  verbose: boolean;
+};
+
+/**
+ * Normalizes raw CLI options into a typed GlobalFlags object.
+ * Handles common aliases and env var fallbacks.
+ *
+ * Pass the output of your argv parser (commander opts, citty args, etc).
+ */
+export function parseGlobalFlags(raw: Record<string, unknown> = {}): GlobalFlags {
+  return {
+    json: Boolean(raw.json ?? process.env.CLI_JSON === "1"),
+    dryRun: Boolean(raw.dryRun ?? raw["dry-run"] ?? false),
+    profile: (raw.profile as string) ?? process.env.CLI_PROFILE ?? undefined,
+    noInput: Boolean(raw.noInput ?? raw["no-input"] ?? process.env.CI === "true"),
+    quiet: Boolean(raw.quiet ?? raw.q ?? false),
+    verbose: Boolean(raw.verbose ?? raw.v ?? false),
+  };
+}
+
+/**
+ * Returns the flag definitions as an array. Useful for registering
+ * with commander, citty, or any argv parser.
+ *
+ * Example with commander:
+ *   for (const f of getGlobalFlagDefs()) {
+ *     program.option(f.flag, f.description);
+ *   }
+ */
+export function getGlobalFlagDefs() {
+  return [
+    { flag: "--json", description: "Emit JSON output for agents" },
+    { flag: "--dry-run", description: "Validate without calling upstream" },
+    { flag: "--profile <name>", description: "Config profile to use" },
+    { flag: "--no-input", description: "Never prompt, fail fast" },
+    { flag: "-q, --quiet", description: "Suppress non-essential output" },
+    { flag: "-v, --verbose", description: "Verbose logging to stderr" },
+  ] as const;
+}

--- a/site/public/r/json-mode.ts
+++ b/site/public/r/json-mode.ts
@@ -1,0 +1,109 @@
+// cligentic block: json-mode
+//
+// Dual-rendering output helpers for CLIs that serve both humans and agents.
+//
+// Design rules:
+//   1. stdout is data. Only structured JSON in --json mode, formatted in human.
+//   2. stderr is logs. Notes, progress, errors.
+//   3. Mode detection is implicit. Piped stdout auto-switches to JSON.
+//   4. Never call process.exit().
+//   5. One call site: emit(value, opts, humanRender?).
+//
+// Usage:
+//   import { detectMode, emit, note, reportError } from "./agent/json-mode";
+//
+//   program.option("--json", "emit JSON for agents");
+//   program.command("list").action(async (opts) => {
+//     const items = await fetchItems();
+//     emit(items, opts, (data) => {
+//       for (const item of data) console.log(`- ${item.name}`);
+//     });
+//   });
+
+import pc from "picocolors";
+import {
+  type EmitOptions,
+  type OutputMode,
+  detectMode,
+  shouldColor,
+} from "../platform/detect";
+
+// Re-export so consumers can import everything from json-mode
+export { type EmitOptions, type OutputMode as Mode, detectMode, shouldColor };
+
+/**
+ * Emits a value to stdout. JSON in json mode, humanRender callback in human.
+ * Arrays emit as NDJSON (one object per line) for agent stream-parsing.
+ */
+export function emit<T>(value: T, opts: EmitOptions = {}, humanRender?: (value: T) => void): void {
+  const mode = detectMode(opts);
+
+  if (mode === "json") {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        process.stdout.write(`${JSON.stringify(item)}\n`);
+      }
+    } else {
+      process.stdout.write(`${JSON.stringify(value)}\n`);
+    }
+    return;
+  }
+
+  if (humanRender) {
+    humanRender(value);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Writes a note to stderr. Suppressed in json mode and quiet mode.
+ */
+export function note(message: string, opts: EmitOptions = {}): void {
+  if (opts.json === true) return;
+  if (!process.stdout.isTTY && opts.json !== false) return;
+  if (opts.quiet) return;
+
+  const colored = shouldColor() ? pc.dim(message) : message;
+  process.stderr.write(`${colored}\n`);
+}
+
+/**
+ * Writes a success message. JSON to stdout in json mode, colored to stderr in human.
+ */
+export function emitSuccess(message: string, opts: EmitOptions = {}): void {
+  const mode = detectMode(opts);
+  if (mode === "json") {
+    process.stdout.write(`${JSON.stringify({ ok: true, message })}\n`);
+    return;
+  }
+  const prefix = shouldColor() ? pc.green("✓") : "✓";
+  process.stderr.write(`${prefix} ${message}\n`);
+}
+
+/**
+ * Reports an error without exiting. JSON to stdout in json mode, colored
+ * to stderr in human. Returns the structured payload for caller inspection.
+ */
+export function reportError(
+  error: string | Error,
+  opts: EmitOptions = {},
+): { ok: false; error: string; stack?: string } {
+  const message = error instanceof Error ? error.message : error;
+  const stack = error instanceof Error ? error.stack : undefined;
+  const payload = { ok: false as const, error: message, ...(stack ? { stack } : {}) };
+
+  const mode = detectMode(opts);
+  if (mode === "json") {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return payload;
+  }
+
+  const prefix = shouldColor() ? pc.red("✗") : "✗";
+  process.stderr.write(`${prefix} ${message}\n`);
+  if (stack && process.env.DEBUG) {
+    process.stderr.write(`${shouldColor() ? pc.dim(stack) : stack}\n`);
+  }
+  return payload;
+}

--- a/site/public/r/killswitch.ts
+++ b/site/public/r/killswitch.ts
@@ -1,0 +1,111 @@
+// cligentic block: killswitch
+//
+// Binary safety gate. If a file exists at ~/.{app}/KILLSWITCH, all write
+// operations refuse to execute. That's it. No config, no database, no
+// network call. File exists = stopped. File gone = resumed.
+//
+// Design rules:
+//   1. File existence is the sole source of truth. Atomic, no race conditions.
+//   2. The file contains a JSON payload with reason + timestamp for debugging.
+//   3. Checking the killswitch is a single fs.existsSync call (< 1ms).
+//   4. Turning it on/off is idempotent.
+//   5. Never throws from isKillswitchOn(). Always returns boolean.
+//
+// Usage:
+//   import { assertKillswitchOff, turnKillswitchOn, turnKillswitchOff, isKillswitchOn } from "./safety/killswitch";
+//
+//   // Guard a write operation
+//   assertKillswitchOff(appHome);  // throws if KILLSWITCH file exists
+//   await placeOrder(order);
+//
+//   // Emergency stop from another terminal
+//   turnKillswitchOn(appHome, "suspicious activity detected");
+//
+//   // Resume after investigation
+//   turnKillswitchOff(appHome);
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type KillswitchState = {
+  active: boolean;
+  reason?: string;
+  activatedAt?: string;
+};
+
+const KILLSWITCH_FILE = "KILLSWITCH";
+
+function getPath(appHome: string): string {
+  return join(appHome, KILLSWITCH_FILE);
+}
+
+/**
+ * Check if the killswitch is active. Fast (single existsSync call).
+ * Never throws.
+ */
+export function isKillswitchOn(appHome: string): boolean {
+  try {
+    return existsSync(getPath(appHome));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the killswitch state including reason and timestamp.
+ * Returns { active: false } if the file doesn't exist or can't be read.
+ */
+export function getKillswitchState(appHome: string): KillswitchState {
+  const path = getPath(appHome);
+  if (!existsSync(path)) return { active: false };
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8"));
+    return { active: true, reason: data.reason, activatedAt: data.at };
+  } catch {
+    return { active: true, reason: "unknown (file exists but unreadable)" };
+  }
+}
+
+/**
+ * Activate the killswitch. Idempotent. Creates the app home directory
+ * if it doesn't exist. Writes reason + timestamp to the file.
+ */
+export function turnKillswitchOn(appHome: string, reason = "manual"): void {
+  mkdirSync(appHome, { recursive: true });
+  writeFileSync(
+    getPath(appHome),
+    JSON.stringify({ reason, at: new Date().toISOString() }, null, 2),
+  );
+}
+
+/**
+ * Deactivate the killswitch. Idempotent. No-op if already off.
+ */
+export function turnKillswitchOff(appHome: string): void {
+  const path = getPath(appHome);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
+
+/**
+ * Assert that the killswitch is off. If it's on, throws an error with
+ * the reason and timestamp. Use this as a guard at the top of any
+ * write operation.
+ *
+ * ```ts
+ * assertKillswitchOff(appHome);
+ * await dangerousOperation();
+ * ```
+ */
+export function assertKillswitchOff(appHome: string): void {
+  const state = getKillswitchState(appHome);
+  if (state.active) {
+    const since = state.activatedAt ? ` since ${state.activatedAt}` : "";
+    const why = state.reason ? `: ${state.reason}` : "";
+    throw new Error(
+      `Killswitch is ON${since}${why}. All write operations are blocked. ` +
+        `Remove ${getPath(appHome)} or run your CLI's killswitch off command to resume.`,
+    );
+  }
+}

--- a/site/public/r/next-steps.ts
+++ b/site/public/r/next-steps.ts
@@ -1,0 +1,94 @@
+// cligentic block: next-steps
+//
+// Post-command guidance for agents and humans. Emit structured "what to do
+// next" hints after a command completes so agents can chain operations
+// without re-planning from scratch, and humans get visible next actions.
+//
+// Design rules:
+//   1. stderr only. Never stdout — stdout is data territory (see json-mode).
+//   2. NDJSON in json mode (one object per line, stream-parseable).
+//   3. Formatted block with arrow bullets in human mode.
+//   4. Never throws, never exits. Pure emission.
+//   5. Each step is { command, description, optional? } — agents key off
+//      `command`, humans read `description`.
+//
+// Usage:
+//   import { emit } from "./json-mode";
+//   import { emitNextSteps } from "./next-steps";
+//
+//   program.command("list").action(async (opts) => {
+//     const items = await fetchItems();
+//     emit(items, opts);
+//     emitNextSteps([
+//       { command: "myapp show <id>", description: "see details for one item" },
+//       { command: "myapp export --format csv", description: "export all items", optional: true },
+//     ], opts);
+//   });
+//
+// Agent consumption (Node/Bun pseudocode):
+//   const proc = spawn("myapp", ["list", "--json"]);
+//   const data = JSON.parse(await readStdout(proc));       // data from emit()
+//   const steps = readStderr(proc)
+//     .split("\n")
+//     .filter(Boolean)
+//     .map(line => JSON.parse(line))
+//     .filter(obj => obj.type === "next-step");             // hints from emitNextSteps()
+//
+//   // Agent now has both data (decisions input) and hints (what to do next).
+//
+// Depends on:
+//   - picocolors (for human-mode coloring)
+//   - json-mode block (chained via registryDependencies — provides detectMode)
+
+import pc from "picocolors";
+import { type EmitOptions, detectMode, shouldColor } from "./json-mode";
+
+export type NextStep = {
+  /** The literal command the user/agent should run next. */
+  command: string;
+  /** A short (2-10 word) hint for why this step matters. */
+  description: string;
+  /** If true, the step is suggested but not required. */
+  optional?: boolean;
+};
+
+/**
+ * Emits a list of next-step hints to stderr.
+ *
+ * In json mode: one NDJSON object per line, each tagged with `type: "next-step"`
+ * so agents can distinguish them from other stderr content.
+ *
+ * In human mode: a formatted block with arrow bullets (→ for required,
+ * ○ for optional) and dim descriptions.
+ *
+ * Does nothing if the steps array is empty.
+ */
+export function emitNextSteps(steps: NextStep[], opts: EmitOptions = {}): void {
+  if (steps.length === 0) return;
+
+  const mode = detectMode(opts);
+
+  if (mode === "json") {
+    for (const step of steps) {
+      process.stderr.write(
+        `${JSON.stringify({ type: "next-step", ...step })}\n`,
+      );
+    }
+    return;
+  }
+
+  // Human mode — formatted block.
+  const color = shouldColor();
+  const header = color ? pc.bold("Next steps:") : "Next steps:";
+  process.stderr.write(`\n${header}\n`);
+
+  for (const step of steps) {
+    const marker = step.optional ? "○" : "→";
+    const cmd = color ? pc.cyan(step.command) : step.command;
+    const desc = color ? pc.dim(step.description) : step.description;
+    process.stderr.write(`  ${marker} ${cmd}  ${desc}\n`);
+  }
+
+  process.stderr.write("\n");
+}
+

--- a/site/public/r/notify-os.ts
+++ b/site/public/r/notify-os.ts
@@ -1,0 +1,77 @@
+// cligentic block: notify-os
+//
+// Fires a system notification across macOS, Linux, Windows, and WSL.
+// Returns a typed verdict instead of throwing.
+//
+// Usage:
+//   import { notifyOs } from "./platform/notify-os";
+//
+//   const result = await notifyOs("Deploy complete", "myapp v1.2.0 is live");
+
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+import { hasCommand, isCi, isWsl } from "./detect";
+
+export type NotifyResult = {
+  sent: boolean;
+  via: "osascript" | "notify-send" | "powershell" | "skipped";
+  reason?: string;
+};
+
+export type NotifyOptions = {
+  dryRun?: boolean;
+  appName?: string;
+  sound?: boolean;
+};
+
+function escapeOsascript(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export async function notifyOs(
+  title: string,
+  message: string,
+  options: NotifyOptions = {},
+): Promise<NotifyResult> {
+  const { dryRun = false, appName = "CLI", sound = true } = options;
+
+  if (isCi()) return { sent: false, via: "skipped", reason: "CI environment" };
+
+  const os = platform();
+
+  if (os === "darwin") {
+    const soundClause = sound ? ' sound name "default"' : "";
+    const cmd = `osascript -e 'display notification "${escapeOsascript(message)}" with title "${escapeOsascript(title)}"${soundClause}'`;
+    if (dryRun) return { sent: true, via: "osascript", reason: `would run: ${cmd}` };
+    try {
+      execSync(cmd, { stdio: "ignore", timeout: 5000 });
+      return { sent: true, via: "osascript" };
+    } catch (err) {
+      return { sent: false, via: "osascript", reason: (err as Error).message };
+    }
+  }
+
+  if (os === "win32" || isWsl()) {
+    const psCmd = `powershell.exe -NoProfile -Command "Add-Type -AssemblyName System.Windows.Forms; $n = New-Object System.Windows.Forms.NotifyIcon; $n.Icon = [System.Drawing.SystemIcons]::Information; $n.Visible = $true; $n.ShowBalloonTip(5000, '${title.replace(/'/g, "''")}', '${message.replace(/'/g, "''")}', 'Info')"`;
+    if (dryRun) return { sent: true, via: "powershell", reason: "would run: PowerShell notification" };
+    try {
+      execSync(psCmd, { stdio: "ignore", timeout: 10000 });
+      return { sent: true, via: "powershell" };
+    } catch (err) {
+      return { sent: false, via: "powershell", reason: (err as Error).message };
+    }
+  }
+
+  if (hasCommand("notify-send")) {
+    const cmd = `notify-send --app-name="${appName}" "${title.replace(/"/g, '\\"')}" "${message.replace(/"/g, '\\"')}"`;
+    if (dryRun) return { sent: true, via: "notify-send", reason: `would run: ${cmd}` };
+    try {
+      execSync(cmd, { stdio: "ignore", timeout: 5000 });
+      return { sent: true, via: "notify-send" };
+    } catch (err) {
+      return { sent: false, via: "notify-send", reason: (err as Error).message };
+    }
+  }
+
+  return { sent: false, via: "skipped", reason: "no notification backend found" };
+}

--- a/site/public/r/open-url.ts
+++ b/site/public/r/open-url.ts
@@ -1,0 +1,126 @@
+// cligentic block: open-url
+//
+// Opens a URL in the user's default browser, across macOS, Linux, Windows,
+// WSL, SSH sessions, and headless CI environments.
+//
+// Design rules:
+//   1. Respect BROWSER env var first (Unix convention).
+//   2. Detect WSL and route through wslview / cmd.exe.
+//   3. Detect headless (no DISPLAY on Linux, SSH without X forwarding).
+//   4. Fall back to printing the URL and letting the user click it.
+//   5. Never throw. Returns a verdict so callers can decide what to do.
+//   6. Never block. Spawn detached so long-lived CLIs don't hang.
+//
+// Usage:
+//   import { openUrl } from "./platform/open-url";
+//
+//   const result = await openUrl("https://cligentic.railly.dev");
+//   if (!result.opened) {
+//     console.log("Please open this URL manually:", result.url);
+//   }
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { hasCommand, isCi, isHeadlessLinux, isWsl } from "./detect";
+
+export type OpenUrlResult = {
+  url: string;
+  opened: boolean;
+  via: "browser-env" | "darwin" | "wsl" | "linux" | "windows" | "manual";
+  reason?: string;
+};
+
+export type OpenUrlOptions = {
+  dryRun?: boolean;
+  manualOnly?: boolean;
+};
+
+function spawnDetached(cmd: string, args: string[]): void {
+  const child = spawn(cmd, args, {
+    detached: true,
+    stdio: "ignore",
+    shell: false,
+  });
+  child.unref();
+}
+
+export async function openUrl(
+  url: string,
+  options: OpenUrlOptions = {},
+): Promise<OpenUrlResult> {
+  const { dryRun = false, manualOnly = false } = options;
+
+  if (manualOnly || isCi() || isHeadlessLinux()) {
+    return {
+      url,
+      opened: false,
+      via: "manual",
+      reason: manualOnly
+        ? "manualOnly flag set"
+        : isCi()
+          ? "CI environment detected"
+          : "headless Linux (no DISPLAY / WAYLAND_DISPLAY)",
+    };
+  }
+
+  const browserEnv = process.env.BROWSER;
+  if (browserEnv && browserEnv !== "none") {
+    if (dryRun) return { url, opened: true, via: "browser-env", reason: `would run: ${browserEnv} ${url}` };
+    try {
+      spawnDetached(browserEnv, [url]);
+      return { url, opened: true, via: "browser-env" };
+    } catch {
+      // fall through
+    }
+  }
+
+  const os = platform();
+
+  if (os === "darwin") {
+    if (dryRun) return { url, opened: true, via: "darwin", reason: `would run: open ${url}` };
+    try {
+      spawnDetached("open", [url]);
+      return { url, opened: true, via: "darwin" };
+    } catch (err) {
+      return { url, opened: false, via: "manual", reason: `open failed: ${(err as Error).message}` };
+    }
+  }
+
+  if (os === "win32") {
+    if (dryRun) return { url, opened: true, via: "windows", reason: "would run: powershell Start-Process" };
+    try {
+      spawnDetached("powershell.exe", ["-NoProfile", "-Command", `Start-Process "${url}"`]);
+      return { url, opened: true, via: "windows" };
+    } catch (err) {
+      return { url, opened: false, via: "manual", reason: `powershell failed: ${(err as Error).message}` };
+    }
+  }
+
+  if (os === "linux" && isWsl()) {
+    if (hasCommand("wslview")) {
+      if (dryRun) return { url, opened: true, via: "wsl", reason: "would run: wslview" };
+      try { spawnDetached("wslview", [url]); return { url, opened: true, via: "wsl" }; } catch { /* fall through */ }
+    }
+    if (hasCommand("cmd.exe")) {
+      if (dryRun) return { url, opened: true, via: "wsl", reason: "would run: cmd.exe /c start" };
+      try { spawnDetached("cmd.exe", ["/c", "start", "", url]); return { url, opened: true, via: "wsl" }; } catch (err) {
+        return { url, opened: false, via: "manual", reason: `wsl cmd.exe failed: ${(err as Error).message}` };
+      }
+    }
+    return { url, opened: false, via: "manual", reason: "WSL without wslview or cmd.exe" };
+  }
+
+  const candidates = ["xdg-open", "gio", "sensible-browser", "firefox", "google-chrome", "chromium"];
+  for (const cmd of candidates) {
+    if (hasCommand(cmd)) {
+      if (dryRun) return { url, opened: true, via: "linux", reason: `would run: ${cmd} ${url}` };
+      try {
+        const args = cmd === "gio" ? ["open", url] : [url];
+        spawnDetached(cmd, args);
+        return { url, opened: true, via: "linux" };
+      } catch { /* try next */ }
+    }
+  }
+
+  return { url, opened: false, via: "manual", reason: "no known browser opener found on PATH" };
+}

--- a/site/public/r/registry.json
+++ b/site/public/r/registry.json
@@ -73,6 +73,23 @@
       "docs": "## Next steps\n\n```ts\nimport { emit } from './agent/json-mode';\nimport { emitNextSteps } from './agent/next-steps';\n\nprogram.command('list').action(async (opts) => {\n  const items = await fetchItems();\n  emit(items, opts);\n  emitNextSteps([\n    { command: 'myapp show <id>', description: 'see details for one item' },\n    { command: 'myapp export', description: 'export all', optional: true },\n  ], opts);\n});\n```\n\nAgents parse `stderr` line-by-line and filter `{type: 'next-step', ...}`\nobjects to know what to try next. Humans see a formatted block with\narrow bullets.\n\n**Note**: this block auto-pulls `json-mode` via `registryDependencies`,\nso you only need to install `next-steps` and shadcn fetches both."
     },
     {
+      "name": "trust-ladder",
+      "type": "registry:file",
+      "title": "trust-ladder",
+      "description": "Approval gate and structured preview renderer for T2/T3 CLI actions. Handles `--yes`, T3 `--confirm`, JSON/non-TTY refusal, and machine-readable AppError failures.",
+      "registryDependencies": [
+        "https://cligentic.railly.dev/r/json-mode.json",
+        "https://cligentic.railly.dev/r/error-map.json"
+      ],
+      "files": [
+        {
+          "path": "registry/agent/trust-ladder.ts",
+          "type": "registry:file",
+          "target": "src/cli/agent/trust-ladder.ts"
+        }
+      ]
+    },
+    {
       "name": "copy-clipboard",
       "type": "registry:file",
       "title": "copy-clipboard",
@@ -140,6 +157,19 @@
           "path": "registry/foundation/audit-log.ts",
           "type": "registry:file",
           "target": "src/cli/foundation/audit-log.ts"
+        }
+      ]
+    },
+    {
+      "name": "audit-lifecycle",
+      "type": "registry:file",
+      "title": "audit-lifecycle",
+      "description": "Two-phase append-only audit lifecycle for dangerous or retryable operations: `beginAudit()` writes pending, then `complete()` or `fail()` appends the final record with the same audit id.",
+      "files": [
+        {
+          "path": "registry/foundation/audit-lifecycle.ts",
+          "type": "registry:file",
+          "target": "src/cli/foundation/audit-lifecycle.ts"
         }
       ]
     },

--- a/site/public/r/session.ts
+++ b/site/public/r/session.ts
@@ -1,0 +1,65 @@
+// cligentic block: session
+//
+// Auth token persistence. Load on boot, save after login, clear on logout,
+// check expiry. Uses atomic writes and 0o600 permissions.
+//
+// Usage:
+//   import { loadSession, saveSession, clearSession, isExpired } from "./foundation/session";
+//
+//   const session = loadSession<MySession>(paths.sessions);
+//   if (!session || isExpired(session.expiresAt)) {
+//     // re-auth
+//   }
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWriteJson } from "./atomic-write";
+
+export type SessionBase = {
+  /** ISO 8601 timestamp when the session was created. */
+  createdAt: string;
+  /** ISO 8601 timestamp when the session expires. Optional. */
+  expiresAt?: string;
+};
+
+const SESSION_FILE = "current.json";
+
+/**
+ * Loads the current session from {sessionsDir}/current.json.
+ * Returns null if no session exists or the file is corrupted.
+ */
+export function loadSession<T extends SessionBase>(sessionsDir: string): T | null {
+  const filePath = join(sessionsDir, SESSION_FILE);
+  if (!existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Saves a session to {sessionsDir}/current.json with 0o600 permissions.
+ * Uses atomic write to prevent corruption.
+ */
+export function saveSession<T extends SessionBase>(sessionsDir: string, session: T): void {
+  atomicWriteJson(join(sessionsDir, SESSION_FILE), session, { mode: 0o600 });
+}
+
+/**
+ * Deletes the current session file.
+ */
+export function clearSession(sessionsDir: string): void {
+  const filePath = join(sessionsDir, SESSION_FILE);
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+  }
+}
+
+/**
+ * Checks if an ISO 8601 expiry timestamp has passed.
+ */
+export function isExpired(expiresAt?: string): boolean {
+  if (!expiresAt) return false;
+  return new Date(expiresAt).getTime() < Date.now();
+}

--- a/site/public/r/skill-installer-prompt.ts
+++ b/site/public/r/skill-installer-prompt.ts
@@ -1,0 +1,118 @@
+// cligentic block: skill-installer-prompt
+//
+// Post-init hook for CLIs that ship a companion agent skill. Asks the
+// user "want the Claude Code / Cursor / MCP-aware skill?" and, on yes,
+// spawns a package manager command with inherited stdio so the user
+// sees the real output.
+//
+// Design rules:
+//   1. Default answer is `true`. Most users who typed `myapp init` will
+//      want the skill; the opt-in tax should be minimal.
+//   2. stdio is inherited. The user sees the package manager's live
+//      progress, errors, and prompts. No wrapping, no filtering.
+//   3. Never throws on installer failure. Returns { installed:false,
+//      error:"..." } so the caller can surface a retry hint.
+//   4. Never throws on cancel. Returns { installed:false, cancelled:true }.
+//   5. Works with any installer command, not just `npx`. Pass the full
+//      argv array (e.g. ["pnpm","dlx","skills","add","owner/repo"]).
+//
+// Usage:
+//   import { offerSkillInstall } from "./agent/skill-installer-prompt";
+//
+//   const outcome = await offerSkillInstall({
+//     skillSlug: "Railly/v0-cli",
+//     command: ["npx", "-y", "skills", "add", "Railly/v0-cli"],
+//     promptMessage: "Install the agent skill for Claude Code / Cursor?",
+//   });
+//
+//   if (outcome.installed) {
+//     // skill is live, chain next step
+//   } else if (outcome.cancelled) {
+//     // user said no or pressed esc — chain without skill
+//   } else {
+//     // installer failed — surface outcome.error, offer retry
+//   }
+//
+// Depends on:
+//   - @clack/prompts (confirm, isCancel, log)
+
+import { spawn } from 'node:child_process'
+import * as p from '@clack/prompts'
+
+export type SkillInstallerPromptOptions = {
+  /**
+   * Label for the skill in logs and hints. Typically the repo slug
+   * ("owner/repo") or a display name ("Agent skill for v0-cli").
+   */
+  skillSlug: string
+  /**
+   * Full argv for the installer. First element is the program name,
+   * the rest are arguments. Defaults to ["npx","-y","skills","add",skillSlug].
+   */
+  command?: string[]
+  /** Prompt shown to the user. Optional; has a sensible default. */
+  promptMessage?: string
+  /** Whether the default selection is Yes. Defaults to true. */
+  initialValue?: boolean
+  /** Skip the confirm prompt entirely. The installer runs unconditionally. */
+  autoYes?: boolean
+  /** Don't offer the install at all. Returns {installed:false,skipped:true}. */
+  skip?: boolean
+}
+
+export type SkillInstallerOutcome =
+  | { installed: true }
+  | { installed: false; cancelled: true }
+  | { installed: false; skipped: true }
+  | { installed: false; error: string }
+
+/**
+ * Prompts the user (unless autoYes / skip), runs the installer with
+ * inherited stdio, returns a discriminated outcome. Never throws.
+ */
+export async function offerSkillInstall(
+  opts: SkillInstallerPromptOptions,
+): Promise<SkillInstallerOutcome> {
+  if (opts.skip) return { installed: false, skipped: true }
+
+  if (!opts.autoYes) {
+    const answer = await p.confirm({
+      message:
+        opts.promptMessage ??
+        `Install ${opts.skillSlug} as an agent skill (Claude Code / Cursor / MCP-aware agents)?`,
+      initialValue: opts.initialValue ?? true,
+    })
+    if (p.isCancel(answer) || !answer) {
+      p.log.info('Skipped skill install.')
+      return { installed: false, cancelled: true }
+    }
+  }
+
+  const argv = opts.command ?? ['npx', '-y', 'skills', 'add', opts.skillSlug]
+  const [program, ...rest] = argv
+  if (!program) {
+    return { installed: false, error: 'empty command array' }
+  }
+
+  p.log.step(`Running: ${argv.join(' ')}`)
+
+  const result = await new Promise<SkillInstallerOutcome>((resolve) => {
+    const child = spawn(program, rest, { stdio: 'inherit' })
+    child.on('exit', (code) => {
+      if (code === 0) resolve({ installed: true })
+      else resolve({ installed: false, error: `${program} exited with code ${code ?? '?'}` })
+    })
+    child.on('error', (err) => {
+      resolve({ installed: false, error: err.message })
+    })
+  })
+
+  if (result.installed) {
+    p.log.success(`Installed ${opts.skillSlug}.`)
+  } else if ('error' in result) {
+    p.log.warn(
+      `Skill install failed (${result.error}). Retry with: ${argv.join(' ')}`,
+    )
+  }
+  return result
+}

--- a/site/public/r/telemetry.ts
+++ b/site/public/r/telemetry.ts
@@ -1,0 +1,98 @@
+// cligentic block: telemetry
+//
+// Anonymous usage tracking for your CLI. Opt-out by default via
+// CLI_NO_TELEMETRY=1 or DO_NOT_TRACK=1 env vars. Respects user privacy.
+//
+// Two modes:
+//   1. Local-only: append events to a JSONL file (for your own analysis)
+//   2. Remote: POST events to a configurable endpoint (for hosted analytics)
+//
+// Usage:
+//   import { trackEvent, isTelemetryEnabled } from "./foundation/telemetry";
+//
+//   if (isTelemetryEnabled()) {
+//     trackEvent(telemetryDir, { event: "command.run", command: "deploy" });
+//   }
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export type TelemetryEvent = {
+  event: string;
+  command?: string;
+  durationMs?: number;
+  result?: "ok" | "error";
+  meta?: Record<string, unknown>;
+};
+
+type StoredEvent = TelemetryEvent & {
+  ts: string;
+  sessionId: string;
+};
+
+export type TelemetryConfig = {
+  /** Remote endpoint to POST events to. If unset, local-only mode. */
+  endpoint?: string;
+  /** Timeout for remote POST in ms. Default 3000. */
+  timeout?: number;
+};
+
+// Session ID: random per process invocation, not per user.
+// No PII. Just groups events from the same CLI run.
+const sessionId = Math.random().toString(36).slice(2, 10);
+
+/**
+ * Checks if telemetry is enabled. Opt-OUT by default means telemetry
+ * is ON unless the user explicitly disables it.
+ *
+ * Respects:
+ *   - CLI_NO_TELEMETRY=1 (your app's env var, replace CLI_ with your prefix)
+ *   - DO_NOT_TRACK=1 (https://consoledonottrack.com)
+ *   - CI environments (always disabled in CI)
+ */
+export function isTelemetryEnabled(): boolean {
+  if (process.env.CLI_NO_TELEMETRY === "1") return false;
+  if (process.env.DO_NOT_TRACK === "1") return false;
+  if (process.env.CI) return false;
+  return true;
+}
+
+/**
+ * Tracks an event. Appends to local JSONL and optionally POSTs to
+ * a remote endpoint. Never throws. Never blocks the CLI.
+ */
+export function trackEvent(
+  telemetryDir: string,
+  event: TelemetryEvent,
+  config: TelemetryConfig = {},
+): void {
+  if (!isTelemetryEnabled()) return;
+
+  const stored: StoredEvent = {
+    ts: new Date().toISOString(),
+    sessionId,
+    ...event,
+  };
+
+  // Local: append to JSONL
+  try {
+    mkdirSync(telemetryDir, { recursive: true });
+    const file = join(telemetryDir, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    appendFileSync(file, `${JSON.stringify(stored)}\n`);
+  } catch {
+    // never fail the CLI over telemetry
+  }
+
+  // Remote: fire-and-forget POST
+  if (config.endpoint) {
+    const timeout = config.timeout ?? 3000;
+    fetch(config.endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(stored),
+      signal: AbortSignal.timeout(timeout),
+    }).catch(() => {
+      // never fail the CLI over telemetry
+    });
+  }
+}

--- a/site/public/r/trust-ladder.json
+++ b/site/public/r/trust-ladder.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "trust-ladder",
+  "title": "trust-ladder",
+  "description": "Approval gate and structured preview renderer for T2/T3 CLI actions. Handles `--yes`, T3 `--confirm`, JSON/non-TTY refusal, and machine-readable AppError failures.",
+  "registryDependencies": [
+    "https://cligentic.railly.dev/r/json-mode.json",
+    "https://cligentic.railly.dev/r/error-map.json"
+  ],
+  "files": [
+    {
+      "path": "registry/agent/trust-ladder.ts",
+      "content": "// cligentic block: trust-ladder\n//\n// Approval gate and preview renderer for T2/T3 CLI actions.\n\nimport { createInterface } from \"node:readline/promises\";\nimport { stdin as defaultStdin, stderr as defaultStderr } from \"node:process\";\nimport { type EmitOptions, detectMode } from \"./json-mode\";\nimport { AppError } from \"../foundation/error-map\";\n\nexport type TrustLevel = \"T0\" | \"T1\" | \"T2\" | \"T3\";\n\nexport type TrustPreview = {\n  title: string;\n  summary: string;\n  details?: Record<string, string | number | boolean | null | undefined>;\n  warning?: string;\n};\n\nexport type ApprovalContext = {\n  cliName?: string;\n  flags?: EmitOptions & { noInput?: boolean };\n  stdin?: NodeJS.ReadableStream & { isTTY?: boolean };\n  stderr?: NodeJS.WritableStream & { isTTY?: boolean };\n};\n\nexport type ApprovalOptions = {\n  trust: TrustLevel;\n  yes?: boolean;\n  confirm?: string;\n  confirmAgainst?: string;\n};\n\nexport async function approveGate(\n  ctx: ApprovalContext,\n  preview: TrustPreview,\n  opts: ApprovalOptions,\n): Promise<boolean> {\n  if (opts.trust !== \"T2\" && opts.trust !== \"T3\") return true;\n\n  if (opts.trust === \"T3\") {\n    const expected = opts.confirmAgainst;\n    if (!opts.confirm || !expected || opts.confirm !== expected) {\n      throw new AppError(\"approval/confirm-mismatch\", {\n        name: \"ApprovalConfirmMismatch\",\n        human: \"Confirmation value does not match the target id.\",\n        hint: \"Pass --yes --confirm <id> for T3 commands.\",\n      });\n    }\n  }\n\n  if (opts.yes === true) return true;\n\n  const flags = ctx.flags ?? {};\n  const input = ctx.stdin ?? defaultStdin;\n  const output = ctx.stderr ?? defaultStderr;\n  const json = detectMode(flags) === \"json\";\n  const noInput = flags.noInput === true;\n  const inputTty = input.isTTY === true;\n  const outputTty = output.isTTY === true;\n\n  if (json || noInput || !inputTty || !outputTty) {\n    const cli = ctx.cliName ?? \"this CLI\";\n    throw new AppError(\"approval/required\", {\n      name: \"ApprovalRequired\",\n      human: `Approval is required before ${cli} can run this operation.`,\n      hint: opts.trust === \"T3\" ? \"Pass --yes --confirm <id>.\" : \"Pass --yes.\",\n    });\n  }\n\n  output.write(`${preview.title}\\n\\n${renderPreview(preview)}\\n\\n`);\n  const rl = createInterface({ input, output });\n  try {\n    const answer = await rl.question(\"Continue? [y/N] \");\n    return answer.trim().toLowerCase() === \"y\" || answer.trim().toLowerCase() === \"yes\";\n  } finally {\n    rl.close();\n  }\n}\n\nexport function renderPreview(preview: TrustPreview, opts: { labelWidth?: number } = {}): string {\n  const labelWidth = opts.labelWidth ?? 14;\n  const rows = Object.entries(preview.details ?? {}).map(([key, value]) => {\n    const lines = String(value ?? \"\").split(\"\\n\");\n    const [first = \"\", ...rest] = lines;\n    const label = `${key}:`.padEnd(labelWidth);\n    const body = [first, ...rest.map((line) => `${\" \".repeat(labelWidth)}${line}`)].join(\"\\n\");\n    return `${label}${body}`;\n  });\n\n  return [\n    preview.summary,\n    ...(rows.length > 0 ? [\"\", ...rows] : []),\n    ...(preview.warning ? [\"\", preview.warning] : []),\n  ].join(\"\\n\");\n}\n",
+      "type": "registry:file",
+      "target": "src/cli/agent/trust-ladder.ts"
+    }
+  ],
+  "type": "registry:file"
+}

--- a/site/public/r/trust-ladder.ts
+++ b/site/public/r/trust-ladder.ts
@@ -1,0 +1,95 @@
+// cligentic block: trust-ladder
+//
+// Approval gate and preview renderer for T2/T3 CLI actions.
+
+import { createInterface } from "node:readline/promises";
+import { stdin as defaultStdin, stderr as defaultStderr } from "node:process";
+import { type EmitOptions, detectMode } from "./json-mode";
+import { AppError } from "../foundation/error-map";
+
+export type TrustLevel = "T0" | "T1" | "T2" | "T3";
+
+export type TrustPreview = {
+  title: string;
+  summary: string;
+  details?: Record<string, string | number | boolean | null | undefined>;
+  warning?: string;
+};
+
+export type ApprovalContext = {
+  cliName?: string;
+  flags?: EmitOptions & { noInput?: boolean };
+  stdin?: NodeJS.ReadableStream & { isTTY?: boolean };
+  stderr?: NodeJS.WritableStream & { isTTY?: boolean };
+};
+
+export type ApprovalOptions = {
+  trust: TrustLevel;
+  yes?: boolean;
+  confirm?: string;
+  confirmAgainst?: string;
+};
+
+export async function approveGate(
+  ctx: ApprovalContext,
+  preview: TrustPreview,
+  opts: ApprovalOptions,
+): Promise<boolean> {
+  if (opts.trust !== "T2" && opts.trust !== "T3") return true;
+
+  if (opts.trust === "T3") {
+    const expected = opts.confirmAgainst;
+    if (!opts.confirm || !expected || opts.confirm !== expected) {
+      throw new AppError("approval/confirm-mismatch", {
+        name: "ApprovalConfirmMismatch",
+        human: "Confirmation value does not match the target id.",
+        hint: "Pass --yes --confirm <id> for T3 commands.",
+      });
+    }
+  }
+
+  if (opts.yes === true) return true;
+
+  const flags = ctx.flags ?? {};
+  const input = ctx.stdin ?? defaultStdin;
+  const output = ctx.stderr ?? defaultStderr;
+  const json = detectMode(flags) === "json";
+  const noInput = flags.noInput === true;
+  const inputTty = input.isTTY === true;
+  const outputTty = output.isTTY === true;
+
+  if (json || noInput || !inputTty || !outputTty) {
+    const cli = ctx.cliName ?? "this CLI";
+    throw new AppError("approval/required", {
+      name: "ApprovalRequired",
+      human: `Approval is required before ${cli} can run this operation.`,
+      hint: opts.trust === "T3" ? "Pass --yes --confirm <id>." : "Pass --yes.",
+    });
+  }
+
+  output.write(`${preview.title}\n\n${renderPreview(preview)}\n\n`);
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question("Continue? [y/N] ");
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+export function renderPreview(preview: TrustPreview, opts: { labelWidth?: number } = {}): string {
+  const labelWidth = opts.labelWidth ?? 14;
+  const rows = Object.entries(preview.details ?? {}).map(([key, value]) => {
+    const lines = String(value ?? "").split("\n");
+    const [first = "", ...rest] = lines;
+    const label = `${key}:`.padEnd(labelWidth);
+    const body = [first, ...rest.map((line) => `${" ".repeat(labelWidth)}${line}`)].join("\n");
+    return `${label}${body}`;
+  });
+
+  return [
+    preview.summary,
+    ...(rows.length > 0 ? ["", ...rows] : []),
+    ...(preview.warning ? ["", preview.warning] : []),
+  ].join("\n");
+}

--- a/site/public/r/xdg-paths.ts
+++ b/site/public/r/xdg-paths.ts
@@ -1,0 +1,134 @@
+// cligentic block: xdg-paths
+//
+// XDG Base Directory Spec resolver with macOS and Windows fallbacks.
+// Gives your CLI a canonical directory layout instead of inventing
+// ~/.myapp/ from scratch every time.
+//
+// Design rules:
+//   1. Respect XDG env vars on Linux (XDG_CONFIG_HOME, XDG_STATE_HOME, etc).
+//   2. Fall back to platform conventions: ~/Library on macOS, %APPDATA% on Windows.
+//   3. Provide an APP_HOME env var override for testing.
+//   4. Create directories lazily (only when ensureHome is called).
+//   5. Pure functions, no side effects except ensureHome.
+//
+// Usage:
+//   import { getAppPaths, ensureHome } from "./foundation/xdg-paths";
+//
+//   const paths = getAppPaths("myapp");
+//   // paths.config  = ~/.config/myapp      (Linux)
+//   // paths.state   = ~/.local/state/myapp  (Linux)
+//   // paths.cache   = ~/.cache/myapp        (Linux)
+//   // paths.home    = ~/.config/myapp       (Linux, alias for config)
+//
+//   ensureHome(paths);  // creates all directories
+
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { platform } from "node:os";
+
+export type AppPaths = {
+  /** Primary config directory. TOML/JSON config files live here. */
+  config: string;
+  /** State directory. Sessions, pending approvals, killswitch file. */
+  state: string;
+  /** Cache directory. Temporary data safe to delete. */
+  cache: string;
+  /** Alias for config. The "home" of your CLI's persistent data. */
+  home: string;
+  /** Audit logs directory. Append-only JSONL files. */
+  audit: string;
+  /** Sessions directory. Auth tokens, refresh tokens. */
+  sessions: string;
+  /** Temporary directory for atomic writes. */
+  tmp: string;
+};
+
+/**
+ * Resolves the canonical directory paths for your CLI app.
+ *
+ * On Linux: follows XDG Base Directory Spec.
+ * On macOS: uses ~/Library/Application Support (config/state) and ~/Library/Caches.
+ * On Windows: uses %APPDATA% (config) and %LOCALAPPDATA% (state/cache).
+ *
+ * The APP_HOME env var (e.g., MYAPP_HOME) overrides everything, useful for
+ * testing and CI where you don't want to pollute the real home directory.
+ */
+export function getAppPaths(appName: string): AppPaths {
+  const envKey = `${appName.toUpperCase().replace(/-/g, "_")}_HOME`;
+  const override = process.env[envKey];
+
+  if (override) {
+    return buildPaths(override);
+  }
+
+  const os = platform();
+  const home = homedir();
+
+  if (os === "darwin") {
+    const appSupport = join(home, "Library", "Application Support", appName);
+    return {
+      config: appSupport,
+      state: appSupport,
+      cache: join(home, "Library", "Caches", appName),
+      home: appSupport,
+      audit: join(appSupport, "audit"),
+      sessions: join(appSupport, "sessions"),
+      tmp: join(appSupport, "tmp"),
+    };
+  }
+
+  if (os === "win32") {
+    const appData = process.env.APPDATA || join(home, "AppData", "Roaming");
+    const localAppData = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    const configDir = join(appData, appName);
+    return {
+      config: configDir,
+      state: join(localAppData, appName),
+      cache: join(localAppData, appName, "cache"),
+      home: configDir,
+      audit: join(configDir, "audit"),
+      sessions: join(configDir, "sessions"),
+      tmp: join(localAppData, appName, "tmp"),
+    };
+  }
+
+  // Linux / WSL / other Unix: XDG
+  const xdgConfig = process.env.XDG_CONFIG_HOME || join(home, ".config");
+  const xdgState = process.env.XDG_STATE_HOME || join(home, ".local", "state");
+  const xdgCache = process.env.XDG_CACHE_HOME || join(home, ".cache");
+  const configDir = join(xdgConfig, appName);
+
+  return {
+    config: configDir,
+    state: join(xdgState, appName),
+    cache: join(xdgCache, appName),
+    home: configDir,
+    audit: join(xdgState, appName, "audit"),
+    sessions: join(configDir, "sessions"),
+    tmp: join(xdgCache, appName, "tmp"),
+  };
+}
+
+/**
+ * Creates all directories in the AppPaths tree. Idempotent.
+ * Permissions: 0o700 for sensitive dirs (sessions), 0o755 for the rest.
+ */
+export function ensureHome(paths: AppPaths): void {
+  for (const dir of [paths.config, paths.state, paths.cache, paths.audit, paths.tmp]) {
+    mkdirSync(dir, { recursive: true, mode: 0o755 });
+  }
+  mkdirSync(paths.sessions, { recursive: true, mode: 0o700 });
+}
+
+function buildPaths(root: string): AppPaths {
+  return {
+    config: root,
+    state: root,
+    cache: join(root, "cache"),
+    home: root,
+    audit: join(root, "audit"),
+    sessions: join(root, "sessions"),
+    tmp: join(root, "tmp"),
+  };
+}

--- a/site/registry-source/agent/trust-ladder.ts
+++ b/site/registry-source/agent/trust-ladder.ts
@@ -1,0 +1,95 @@
+// cligentic block: trust-ladder
+//
+// Approval gate and preview renderer for T2/T3 CLI actions.
+
+import { createInterface } from "node:readline/promises";
+import { stdin as defaultStdin, stderr as defaultStderr } from "node:process";
+import { type EmitOptions, detectMode } from "./json-mode";
+import { AppError } from "../foundation/error-map";
+
+export type TrustLevel = "T0" | "T1" | "T2" | "T3";
+
+export type TrustPreview = {
+  title: string;
+  summary: string;
+  details?: Record<string, string | number | boolean | null | undefined>;
+  warning?: string;
+};
+
+export type ApprovalContext = {
+  cliName?: string;
+  flags?: EmitOptions & { noInput?: boolean };
+  stdin?: NodeJS.ReadableStream & { isTTY?: boolean };
+  stderr?: NodeJS.WritableStream & { isTTY?: boolean };
+};
+
+export type ApprovalOptions = {
+  trust: TrustLevel;
+  yes?: boolean;
+  confirm?: string;
+  confirmAgainst?: string;
+};
+
+export async function approveGate(
+  ctx: ApprovalContext,
+  preview: TrustPreview,
+  opts: ApprovalOptions,
+): Promise<boolean> {
+  if (opts.trust !== "T2" && opts.trust !== "T3") return true;
+
+  if (opts.trust === "T3") {
+    const expected = opts.confirmAgainst;
+    if (!opts.confirm || !expected || opts.confirm !== expected) {
+      throw new AppError("approval/confirm-mismatch", {
+        name: "ApprovalConfirmMismatch",
+        human: "Confirmation value does not match the target id.",
+        hint: "Pass --yes --confirm <id> for T3 commands.",
+      });
+    }
+  }
+
+  if (opts.yes === true) return true;
+
+  const flags = ctx.flags ?? {};
+  const input = ctx.stdin ?? defaultStdin;
+  const output = ctx.stderr ?? defaultStderr;
+  const json = detectMode(flags) === "json";
+  const noInput = flags.noInput === true;
+  const inputTty = input.isTTY === true;
+  const outputTty = output.isTTY === true;
+
+  if (json || noInput || !inputTty || !outputTty) {
+    const cli = ctx.cliName ?? "this CLI";
+    throw new AppError("approval/required", {
+      name: "ApprovalRequired",
+      human: `Approval is required before ${cli} can run this operation.`,
+      hint: opts.trust === "T3" ? "Pass --yes --confirm <id>." : "Pass --yes.",
+    });
+  }
+
+  output.write(`${preview.title}\n\n${renderPreview(preview)}\n\n`);
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question("Continue? [y/N] ");
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+export function renderPreview(preview: TrustPreview, opts: { labelWidth?: number } = {}): string {
+  const labelWidth = opts.labelWidth ?? 14;
+  const rows = Object.entries(preview.details ?? {}).map(([key, value]) => {
+    const lines = String(value ?? "").split("\n");
+    const [first = "", ...rest] = lines;
+    const label = `${key}:`.padEnd(labelWidth);
+    const body = [first, ...rest.map((line) => `${" ".repeat(labelWidth)}${line}`)].join("\n");
+    return `${label}${body}`;
+  });
+
+  return [
+    preview.summary,
+    ...(rows.length > 0 ? ["", ...rows] : []),
+    ...(preview.warning ? ["", preview.warning] : []),
+  ].join("\n");
+}

--- a/site/registry-source/foundation/audit-lifecycle.ts
+++ b/site/registry-source/foundation/audit-lifecycle.ts
@@ -1,0 +1,80 @@
+// cligentic block: audit-lifecycle
+//
+// Two-phase append-only audit records for operations that must survive retries.
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+export type AuditLifecycleResult = "pending" | "ok" | "error" | "blocked" | "dry-run";
+
+export type AuditLifecycleRecord = {
+  kind: string;
+  command: string;
+  meta?: Record<string, unknown>;
+  tier?: string;
+  profile?: string;
+};
+
+export type AuditLifecycle = {
+  auditId: string;
+  complete(meta?: Record<string, unknown>): void;
+  fail(meta?: Record<string, unknown>): void;
+  block(meta?: Record<string, unknown>): void;
+  dryRun(meta?: Record<string, unknown>): void;
+};
+
+type StoredLifecycleRecord = AuditLifecycleRecord & {
+  ts: string;
+  result: AuditLifecycleResult;
+  meta: Record<string, unknown>;
+};
+
+function todayFilename(): string {
+  return `${new Date().toISOString().slice(0, 10)}.jsonl`;
+}
+
+export function beginAudit(
+  auditDir: string,
+  record: AuditLifecycleRecord,
+  opts: { auditId?: string } = {},
+): AuditLifecycle {
+  const auditId = opts.auditId ?? randomUUID();
+  const started = Date.now();
+  const baseMeta = { ...(record.meta ?? {}), audit_id: auditId };
+
+  appendLifecycleRecord(auditDir, record, "pending", baseMeta);
+
+  const finish = (result: Exclude<AuditLifecycleResult, "pending">, meta = {}) => {
+    appendLifecycleRecord(auditDir, record, result, {
+      ...baseMeta,
+      ...meta,
+      duration_ms: Date.now() - started,
+    });
+  };
+
+  return {
+    auditId,
+    complete: (meta) => finish("ok", meta),
+    fail: (meta) => finish("error", meta),
+    block: (meta) => finish("blocked", meta),
+    dryRun: (meta) => finish("dry-run", meta),
+  };
+}
+
+export function appendLifecycleRecord(
+  auditDir: string,
+  record: AuditLifecycleRecord,
+  result: AuditLifecycleResult,
+  meta: Record<string, unknown> = {},
+): void {
+  mkdirSync(auditDir, { recursive: true });
+  const file = join(auditDir, todayFilename());
+  const stored: StoredLifecycleRecord = {
+    ts: new Date().toISOString(),
+    ...record,
+    result,
+    meta,
+  };
+  appendFileSync(file, `${JSON.stringify(stored)}\n`, { mode: 0o600 });
+}

--- a/site/registry.json
+++ b/site/registry.json
@@ -73,6 +73,23 @@
       "docs": "## Next steps\n\n```ts\nimport { emit } from './agent/json-mode';\nimport { emitNextSteps } from './agent/next-steps';\n\nprogram.command('list').action(async (opts) => {\n  const items = await fetchItems();\n  emit(items, opts);\n  emitNextSteps([\n    { command: 'myapp show <id>', description: 'see details for one item' },\n    { command: 'myapp export', description: 'export all', optional: true },\n  ], opts);\n});\n```\n\nAgents parse `stderr` line-by-line and filter `{type: 'next-step', ...}`\nobjects to know what to try next. Humans see a formatted block with\narrow bullets.\n\n**Note**: this block auto-pulls `json-mode` via `registryDependencies`,\nso you only need to install `next-steps` and shadcn fetches both."
     },
     {
+      "name": "trust-ladder",
+      "type": "registry:file",
+      "title": "trust-ladder",
+      "description": "Approval gate and structured preview renderer for T2/T3 CLI actions. Handles `--yes`, T3 `--confirm`, JSON/non-TTY refusal, and machine-readable AppError failures.",
+      "registryDependencies": [
+        "https://cligentic.railly.dev/r/json-mode.json",
+        "https://cligentic.railly.dev/r/error-map.json"
+      ],
+      "files": [
+        {
+          "path": "registry/agent/trust-ladder.ts",
+          "type": "registry:file",
+          "target": "src/cli/agent/trust-ladder.ts"
+        }
+      ]
+    },
+    {
       "name": "copy-clipboard",
       "type": "registry:file",
       "title": "copy-clipboard",
@@ -140,6 +157,19 @@
           "path": "registry/foundation/audit-log.ts",
           "type": "registry:file",
           "target": "src/cli/foundation/audit-log.ts"
+        }
+      ]
+    },
+    {
+      "name": "audit-lifecycle",
+      "type": "registry:file",
+      "title": "audit-lifecycle",
+      "description": "Two-phase append-only audit lifecycle for dangerous or retryable operations: `beginAudit()` writes pending, then `complete()` or `fail()` appends the final record with the same audit id.",
+      "files": [
+        {
+          "path": "registry/foundation/audit-lifecycle.ts",
+          "type": "registry:file",
+          "target": "src/cli/foundation/audit-lifecycle.ts"
         }
       ]
     },

--- a/site/scripts/prebuild.sh
+++ b/site/scripts/prebuild.sh
@@ -53,4 +53,35 @@ else
   rm -f registry
 fi
 
+# Step 3: emit the raw .ts next to each block JSON.
+#
+# The JSON is the registry contract, but copy-paste should not require a
+# component installer or `jq`. Every built block already carries its full
+# source in files[0].content, so /r/<block>.ts is a projection of what is
+# already there, with no second source of truth.
+#
+#   curl -o src/lib/atomic-write.ts https://cligentic.railly.dev/r/atomic-write.ts
+#
+# Skips registry.json (the manifest, which has no files) and any entry
+# without file content. Uses node so the step has no jq dependency.
+echo "[prebuild] Emitting raw .ts files into site/public/r/"
+node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const dir = process.argv[1];
+let written = 0;
+for (const entry of fs.readdirSync(dir)) {
+  if (!entry.endsWith(".json") || entry === "registry.json") continue;
+  const parsed = JSON.parse(fs.readFileSync(path.join(dir, entry), "utf8"));
+  const content = parsed.files?.[0]?.content;
+  if (typeof content !== "string" || content.length === 0) {
+    console.warn(`[prebuild]   skipped ${entry}: no file content`);
+    continue;
+  }
+  fs.writeFileSync(path.join(dir, entry.replace(/\.json$/, ".ts")), content);
+  written++;
+}
+console.log(`[prebuild]   wrote ${written} raw .ts files`);
+' "$SITE_DIR/public/r"
+
 echo "[prebuild] Done"

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -37,6 +37,7 @@
   ],
   "exclude": [
     "node_modules",
-    "registry-source"
+    "registry-source",
+    "public/r"
   ]
 }


### PR DESCRIPTION
Closes #5.

## Problem

The registry served only `/r/<block>.json`. Copying a block meant either running a component installer (which expects a project config file that means nothing in a CLI, and leaves a stray one behind) or having `jq` around to pull `files[0].content` out of the JSON.

That undercuts the pitch. The README says copy-paste blocks you own completely, with no framework lock-in, and then the frictionless path assumes UI tooling.

## Fix

`prebuild` now projects the raw source next to each built JSON. A block is one curl:

```bash
curl -o src/lib/atomic-write.ts https://cligentic.railly.dev/r/atomic-write.ts
```

The content already lives in `files[0].content` of every built JSON, so this is a projection of what is there, not a second source of truth. The step runs after `shadcn build`, skips `registry.json` (the manifest has no files), warns on any entry without content, and uses `node` so it adds no `jq` dependency to the build.

## The mimetype trap

Static servers map the `.ts` extension to `video/mp2t`, MPEG transport stream. Confirmed locally: a plain static server returns `Content-type: video/mp2t` for a block. `curl -o` still writes the right bytes, but a browser tries to download it as video instead of displaying it.

`next.config.ts` now sets `text/plain; charset=utf-8` on `/r/*.ts`. The existing `/r/:path*` rule keeps CORS and cache headers for both formats.

## Verification

Ran the build and checked the output rather than assuming:

- 22 raw `.ts` files emitted, one per block.
- All 22 **byte-identical** to their source in `registry/` (`diff -q`, zero differences).
- Next dev serves `/r/atomic-write.ts` as `200`, `Content-Type: text/plain; charset=utf-8`, `Access-Control-Allow-Origin: *`, 2587 bytes, valid TypeScript with its exports intact.
- `/r/atomic-write.json` unchanged: `200`, `application/json`.

## Incidental fix

`site/registry.json` was missing `trust-ladder` and `audit-lifecycle`. Both were added to the repo-root manifest in 9b39994 but never synced into `site/`, so the site's copy listed 19 blocks while the real registry had 21. The prebuild sync corrected it, and the diff is included here rather than left dangling.

## Not included

`registryDependencies` stays JSON-only. A raw consumer resolves them by reading the JSON when needed:

```bash
curl -s https://cligentic.railly.dev/r/trust-ladder.json | jq -r '.registryDependencies[]?'
```

Encoding a dependency list into a `.ts` comment would duplicate the contract in a place nothing parses.